### PR TITLE
Fix README - ping is not eager

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ end
     |> Sitemapper.generate(config)
     |> Sitemapper.persist(config)
     |> Sitemapper.ping(config)
+    |> Stream.run()
   end
 ```
 
@@ -63,6 +64,7 @@ end
       |> Sitemapper.generate(config)
       |> Sitemapper.persist(config)
       |> Sitemapper.ping(config)
+      |> Stream.run()
     end)
   end
 ```
@@ -77,8 +79,6 @@ To persist your sitemaps to the local file system, instead of Amazon S3, your co
   ]
 ]
 ```
-
-Note that `Sitemapper.ping/1` is eager and will execute the stream. If you don't want to ping your sitemap, you'll need to finish on `Stream.run/1` or `Enum.to_list/1` to execute the stream and return the result.
 
 ## Todo
 


### PR DESCRIPTION
Hi! I was adding this library to my own project when I noticed that running `Sitemapper.ping/2` doesn't really execute the stream (I'm using v0.6.0). `Stream.run/1` is always needed.
